### PR TITLE
pin pyvoi version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ tqdm>=4.67.1
 einops>=0.8.0
 timm>=1.0.11
 plotly>=5.24.1
-python-voi>=0.0.3
+python-voi==0.0.2
 scikit-image>=0.24.0
 navis>=1.9.1
 pandas>=2.2.3


### PR DESCRIPTION
pyvoi version 0.0.3 had import problems. Pinning version 0.0.2 for now. 